### PR TITLE
Format Python code with psf/black push

### DIFF
--- a/train.py
+++ b/train.py
@@ -1,1 +1,1 @@
-print("HI" )
+print("HI")


### PR DESCRIPTION
There appear to be some python formatting errors in e1f126939b911ffb0470b363e880bc7f8b9efb0f. This pull request
uses the [psf/black](https://github.com/psf/black) formatter to fix these issues.